### PR TITLE
Add collapse classes to remove margins

### DIFF
--- a/src/baseline.sass
+++ b/src/baseline.sass
@@ -21,6 +21,13 @@ body
 [class*=bl-padding][class*=bl-]
   box-sizing: content-box
 
+.bl-collapse-t
+  margin-top: 0
+.bl-collapse-b
+  margin-bottom: 0
+.bl-collapse-v
+  @extend .bl-collapse-b
+  @extend .bl-collapse-t
 
 =bl-typo($bl-ty-val)
   margin: 0

--- a/src/baseline.scss
+++ b/src/baseline.scss
@@ -24,6 +24,19 @@ body {
   box-sizing: content-box;
 }
 
+.bl-collapse-t {
+  margin-top: 0;
+}
+
+.bl-collapse-b {
+  margin-bottom: 0;
+}
+
+.bl-collapse-v {
+  @extend .bl-collapse-b;
+  @extend .bl-collapse-t;
+}
+
 @mixin bl-typo($bl-ty-val) {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
This add three classes to collapse the margins (top/bottom/vertical).

This is used to collapse margins resulting from another classes or something like that.